### PR TITLE
Update wallets.md

### DIFF
--- a/src/docs/beacon/wallets.md
+++ b/src/docs/beacon/wallets.md
@@ -30,7 +30,7 @@ Wallets are encouraged to support all features that Beacon offers. Please refer 
 | ------------------------- | -------------------- | --------------------------------------------- | ----- | ------ | ------- |
 | permissionRequest         | ✅                   | ✅                                            | ✅    | ✅     | ✅      |
 | operationRequest          | ✅                   | ✅                                            | ✅    | ✅     | ✅      |
-| signRequest (RAW)         | ❌ <br /> (HEX only) | ❌ <br /> (05 or 03 prefixed operations only) | ✅    | ✅     | ❌      |
+| signRequest (RAW)         | ✅                   | ❌ <br /> (05 or 03 prefixed operations only) | ✅    | ✅     | ❌      |
 | signRequest (MICHELINE)   | ✅                   | ✅                                            | ✅    | ✅     | ❌      |
 | signRequest (TRANSACTION) | ✅                   | ✅                                            | ✅    | ✅     | ❌      |
 | broadcastRequest          | ✅                   | ❌                                            | ✅    | ✅     | ❓      |


### PR DESCRIPTION
The support of signRequest (RAW) was added in the latest Temple release. It now allows providing strings in plain text instead of hex.